### PR TITLE
fix bugs

### DIFF
--- a/errorstr.go
+++ b/errorstr.go
@@ -1,0 +1,9 @@
+package winapi
+
+import (
+	"strconv"
+)
+
+func Errstr(code int) string {
+	return "Error code:" + strconv.Itoa(code)
+}

--- a/ole32.go
+++ b/ole32.go
@@ -439,7 +439,7 @@ func init() {
 	// FIXME: Find a way to call OleUninitialize at app shutdown
 	// Maybe we should require explicit walk.Initialize/walk.Shutdown?
 	if hr := OleInitialize(); FAILED(hr) {
-		panic("OleInitialize Error: " + syscall.Errstr(int(hr)))
+		panic("OleInitialize Error: " + Errstr(int(hr)))
 	}
 }
 

--- a/winapi.go
+++ b/winapi.go
@@ -44,18 +44,18 @@ type GUID struct {
 }
 
 func MustLoadLibrary(name string) uintptr {
-	lib, errno := syscall.LoadLibrary(name)
-	if errno != 0 {
-		panic(fmt.Sprintf(`syscall.LoadLibrary("%s") failed: %s`, name, syscall.Errstr(errno)))
+	lib, err := syscall.LoadLibrary(name)
+	if err != nil {
+		panic(fmt.Sprintf(`syscall.LoadLibrary("%s") failed: %s`, name, err))
 	}
 
 	return uintptr(lib)
 }
 
 func MustGetProcAddress(lib uintptr, name string) uintptr {
-	addr, errno := syscall.GetProcAddress(syscall.Handle(lib), name)
-	if errno != 0 {
-		panic(fmt.Sprintf(`syscall.GetProcAddress(%d, "%s") failed: %s`, lib, name, syscall.Errstr(errno)))
+	addr, err := syscall.GetProcAddress(syscall.Handle(lib), name)
+	if err != nil {
+		panic(fmt.Sprintf(`syscall.GetProcAddress(%d, "%s") failed: %s`, lib, name, err))
 	}
 
 	return uintptr(addr)


### PR DESCRIPTION
In current golang version, syscall.LoadLibrary and syscall.GetProcAddress proc returns a error type, not int.
So it should be modified.
